### PR TITLE
Fix Notcoin Foundation wallet name

### DIFF
--- a/source/community.yaml
+++ b/source/community.yaml
@@ -33,7 +33,7 @@
   type: nft_collection
   
 - address: UQAQQTyWQnLTmerS0GWQYrFYtLogGuXAW_kG5gw-50RVpMge
-  name: Gram Foundation
+  name: Notcoin Foundation
   type: wallet
   
 - address: EQCjk1hh952vWaE9bRguFkAhDAL5jj3xj9p0uPWrFBq_GEMS


### PR DESCRIPTION
Probably copy-paste from above result in two Gram Foundation wallets when this wallet accually "Notcoin Foundation"

tonviewer with this address https://tonviewer.com/EQAQQTyWQnLTmerS0GWQYrFYtLogGuXAW_kG5gw-50RVpJXb