### PR TITLE
Add 2Miners payout address

### DIFF
--- a/source/community.yaml
+++ b/source/community.yaml
@@ -157,3 +157,6 @@
 
 - address: UQC_QucgGZcvAYu2a96i76GByKEs2OYq896ro0gagorB6v1t
   name: Official Gramcoin Mining Pool
+
+- address: UQC-4p-7hC-cAt7RvD1qZQrnp1BUU1ba5CYMiQEAQlOu6HOJ
+  name: 2Miners.com Mining Pool (TON Payouts)


### PR DESCRIPTION
Adding the 2Miners.com mining pool payout address that is used by the payouts system (miners can mine altcoins and automatically get paid in TON).