### PR TITLE
Add Hipo treasury and hGRAM jetton

### DIFF
--- a/source/validators.yaml
+++ b/source/validators.yaml
@@ -703,3 +703,12 @@
 - address: Uf_VLM1r87BTTtYoKBmXwDBh7UwfQb_gb36ZC0Ee542q767V
   name: TON Strategy Validator 40
   type: wallet
+
+# Hipo
+- address: EQCLyZHP4Xe8fpchQz76O-_RmUhaVc_9BAoGyJrwJrcbz2eZ
+  name: Hipo Treasury
+  type: pool
+
+- address: EQDPdq8xjAhytYqfGSX8KcFWIReCufsB9Wdg0pLlYSO_h76w
+  name: hGRAM
+  type: jetton


### PR DESCRIPTION
Adds [Hipo](https://hipo.finance), the liquid staking protocol on TON: the treasury (pool) contract `EQCLyZHP4Xe8fpchQz76O-_RmUhaVc_9BAoGyJrwJrcbz2eZ` and the hGRAM jetton master `EQDPdq8xjAhytYqfGSX8KcFWIReCufsB9Wdg0pLlYSO_h76w`, following the pool + jetton pattern used by the other liquid staking protocols in `validators.yaml`. `npm test` passes (all yaml valid, 728 addresses checked). Submitted by the Hipo team.

🤖 Generated with [Claude Code](https://claude.com/claude-code)